### PR TITLE
Deprecated device_state_attribute (#20)

### DIFF
--- a/custom_components/google_keep/sensor.py
+++ b/custom_components/google_keep/sensor.py
@@ -72,7 +72,7 @@ class GoogleKeepSensor(Entity):
         return None
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         attr = dict()
         attr['notes'] = self._notes
         attr[CONF_TITLES] = self._titles


### PR DESCRIPTION
Bare minimum testing on my instance: Google Keep lists are still present and appear to work as usual.  Message is gone from the startup noise.